### PR TITLE
fix: decode `%40` before parsing URLs for `@`

### DIFF
--- a/modules/utils/parsePackageURL.js
+++ b/modules/utils/parsePackageURL.js
@@ -2,20 +2,13 @@ const url = require('url');
 
 const packageURLFormat = /^\/((?:@[^/@]+\/)?[^/@]+)(?:@([^/]+))?(\/.*)?$/;
 
-function decodeParam(param) {
-  if (param) {
-    try {
-      return decodeURIComponent(param);
-    } catch (error) {
-      // Ignore invalid params.
-    }
-  }
-
-  return '';
-}
-
 function parsePackageURL(originalURL) {
   const { pathname, search, query } = url.parse(originalURL, true);
+  try {
+    pathname = decodeURIComponent(pathname);
+  } catch (error) {
+    return null;
+  }
   const match = packageURLFormat.exec(pathname);
 
   // Disallow invalid URL formats.
@@ -24,8 +17,8 @@ function parsePackageURL(originalURL) {
   }
 
   const packageName = match[1];
-  const packageVersion = decodeParam(match[2]) || 'latest';
-  const filename = decodeParam(match[3]);
+  const packageVersion = match[2] || 'latest';
+  const filename = match[3] || '';
 
   return {
     // If the URL is /@scope/name@version/file.js?main=browser:


### PR DESCRIPTION
I'm throwing this up as a possible solution to close #164. 

**Benefits:**
The main one for me is I could use `unpkg` as a host for JSON schema files associated with my npm packages, and reference them in VS Code. But there are probably other HTTP clients besides VS Code conservatively formatting `@` as `%40` that would benefit from this change.

**Risks:**
There is a possibility it would cause a regression because it is running `decodeURIComponent` on the whole path instead of just part. But it would technically only be rejecting URLs that are malformed in the first place (I think).